### PR TITLE
fixed reference to dracut.conf.d folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ sudo cp dsdt.aml /boot/acpi_override/x1yg3-s3-override.aml
 
 ### Configure ACPI override for `dracut`
 
-Create `/etc/dracut.conf/acpi.conf` and add the following lines:
+Create `/etc/dracut.conf.d/acpi.conf` and add the following lines:
 
 ``` shell
 acpi_override="yes"


### PR DESCRIPTION
fixed reference to /etc/dracut.conf.d folder for acpi.conf file